### PR TITLE
Update 0.-praktika.md

### DIFF
--- a/11.-mpls-l3vpn/11.1.-mpls-l3vpn-i-dostup-v-internet/1.-vrf-aware-nat/0.-praktika.md
+++ b/11.-mpls-l3vpn/11.1.-mpls-l3vpn-i-dostup-v-internet/1.-vrf-aware-nat/0.-praktika.md
@@ -38,7 +38,7 @@ Linkmeup_R1(config)#access-list 100 permit ip 192.168.0.0 0.0.255.255 any
 И собственно сам NAT:
 
 ```text
-Linkmeup_R1(config)#$ip nat inside source list 100 interface FastEthernet 1/1 overload
+Linkmeup_R1(config)#$ip nat inside source list 100 interface FastEthernet 1/1 vrf C3PO overload
 ```
 
 **3\)** В BGP, как и в прошлый раз, прописываем отправку маршрута по умолчанию в данный VRF:


### PR DESCRIPTION
Добавлено vrf "C3PO"  без который, nat'ирование не отрабатывает
было "Linkmeup_R1(config)#$ip nat inside source list 100 interface FastEthernet 1/1 overload"
стало "Linkmeup_R1(config)#$ip nat inside source list 100 interface FastEthernet 1/1 vrf C3PO overload"